### PR TITLE
elwin: raise 400 on no results from mongo

### DIFF
--- a/elwin.py
+++ b/elwin.py
@@ -74,13 +74,14 @@ def get_experiments_for_team():
         return "must have equal number of unit-type and unit", 400
 
     try:
-        out_dict = {}
-        out_dict["experiments"] = experiments.get_experiment_params_for_team(
+        exps = experiments.get_experiment_params_for_team(
             group_id, unit_type, unit)
+    except ValueError as e:
+        return str(e), 400
+    else:
+        out_dict = {}
+        out_dict["experiments"] = exps
         return jsonify(out_dict), 200
-    except:
-        return jsonify({"error": "Team Name Not Found"}), 500
-
 
 @app.route("/healthz")
 def get_health():

--- a/elwin.py
+++ b/elwin.py
@@ -77,7 +77,7 @@ def get_experiments_for_team():
         exps = experiments.get_experiment_params_for_team(
             group_id, unit_type, unit)
     except ValueError as e:
-        return str(e), 400
+        return str(e), 404
     else:
         out_dict = {}
         out_dict["experiments"] = exps

--- a/experiments.py
+++ b/experiments.py
@@ -63,6 +63,8 @@ class Experiments:
 
                 params = exp.get_params()
                 res[exp.name] = params
+        if not res:
+            raise ValueError("Not found, group-id: %s, unit-type: %s" % (team_name, unit_type))
         return res
 
     def get_segment(self, name, num_segments, **units):


### PR DESCRIPTION
When a user has a valid query but there are no results we should warn
them that the data doesn't exist rather than returning an empty
experiment.