### PR TITLE
elwin: use query params as key:value units

### DIFF
--- a/elwin.py
+++ b/elwin.py
@@ -39,20 +39,20 @@ def get_experiments_for_team():
     """
 
     group_id = request.args.get('group-id')
-    unit_type = request.args.getlist('unit-type')
-    unit = request.args.getlist('unit')
 
-    if not group_id or not unit_type or not unit:
-        return "must supply group-id, unit-type, and unit", 400
-
-    if not len(unit_type) == len(unit):
-        return "must have equal number of unit-type and unit", 400
+    if not group_id:
+        return "must supply group-id", 400
+    
+    if len(request.args) == 1:
+        return "must supply other params", 400
 
     try:
         exps = experiments.get_experiment_params_for_team(
-            group_id, unit_type, unit)
+            group_id, request.args)
     except ValueError as e:
         return str(e), 404
+    except Exception, e:
+        return jsonify({"error": str(e)}), 500
     else:
         out_dict = {}
         out_dict["experiments"] = exps

--- a/elwin.py
+++ b/elwin.py
@@ -42,7 +42,7 @@ def get_experiments_for_team():
 
     if not group_id:
         return "must supply group-id", 400
-    
+
     if len(request.args) == 1:
         return "must supply other params", 400
 

--- a/storage.py
+++ b/storage.py
@@ -30,7 +30,7 @@ class queryCentralStorage(object):
         pass
 
     @abstractmethod
-    def get_exps_params_by_group_id(self, group_id):
+    def get_exps_params_by_group_id(self, group_id, unit_type):
         pass
 
 
@@ -62,6 +62,9 @@ class queryMongoStorage(queryCentralStorage):
         # TODO(andrew.oneill@nordstrom.com): make mongo config env vars
         self.db = self.client.test_database
         self.dataset = dataset
+
+    def get_exp_params_by_exp_name(self, exp_name):
+        pass
 
     def get_exps_params_by_group_id(self, group_id, unit_type):
         namespaces = self.db[self.dataset].find({

--- a/storage.py
+++ b/storage.py
@@ -64,6 +64,14 @@ class queryMongoStorage(queryCentralStorage):
         self.dataset = dataset
 
     def get_exps_params_by_group_id(self, group_id, unit_type):
-        namespaces = self.db[self.dataset].find({"group_ids": group_id, "units": unit_type})
-        return ((ns['name'], ns['num_segments'], ns['experiments'])
-                for ns in namespaces if ns['experiments'])
+        namespaces = self.db[self.dataset].find({
+            "group_ids": group_id,
+            "units": {
+                "$not": {
+                    "$elemMatch": {
+                        "$nin": unit_type
+                        }
+                    }
+                }
+            })
+        return (ns for ns in namespaces if ns['experiments'])

--- a/test/test.py
+++ b/test/test.py
@@ -61,12 +61,13 @@ csc.add_experiment('test', 'epe-1', 'imageTest', 10, {
                 "choices": {
                     "op": "array",
                     "values": [
-                        "availabilityInfo"
+                        "availabilityInfo",
+                        "unavailabilityInfo"
                     ]
                 },
                 "unit": {
                     "op": "get",
-                    "var": "unit"
+                    "var": "userid"
                 },
                 "op": "uniformChoice"
             }
@@ -89,8 +90,17 @@ csc.add_experiment('test', 'epe-2', 'colorTest', 8, {
                     ]
                 },
                 "unit": {
-                    "op": "get",
-                    "var": "unit"
+                    "op": "array",
+                    "values": [
+                        {
+                            "op": "get",
+                            "var": "userid"
+                        },
+                        {
+                            "op": "get",
+                            "var": "test"
+                        }
+                    ]
                 },
                 "op": "uniformChoice"
             }
@@ -115,7 +125,7 @@ csc.add_experiment('test', 'loy-1', 'checkoutTest', 10, {
                 },
                 "unit": {
                     "op": "get",
-                    "var": "unit"
+                    "var": "userid"
                 },
                 "op": "uniformChoice"
             }


### PR DESCRIPTION
This should simplify querying elwin significantly. Now the only required
parameter would be `group-id`. Fixes #8, Fixes #9.